### PR TITLE
Set tighter lower-bound on base

### DIFF
--- a/servant-ruby.cabal
+++ b/servant-ruby.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Servant.Ruby
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , casing >= 0.1 && < 0.2
                      , lens >= 4.15 && < 4.16
                      , servant-foreign >= 0.9 && < 0.11
@@ -25,6 +25,7 @@ library
   ghc-options:         -Wall
 
 test-suite doc-test
+  default-language:    Haskell2010
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   hs-source-dirs:      test


### PR DESCRIPTION
Currently this package is compatible only with base-4.8 and later, as with base-4.7 the compile failure below occurs.
So this sets the bound more accurately to describe which versions `servant-ruby` is compatible with.

```
Configuring component lib from servant-ruby-0.1.2.0...
Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
Preprocessing library servant-ruby-0.1.2.0...
[1 of 1] Compiling Servant.Ruby     ( src/Servant/Ruby.hs, /tmp/matrix-worker/1489983667/dist-newstyle/build/x86_64-linux/ghc-7.8.4/servant-ruby-0.1.2.0/build/Servant/Ruby.o )

src/Servant/Ruby.hs:20:23:
    Module ‘Data.Function’ does not export ‘(&)’
```