### PR TITLE
Bump version to 0.8.0.0

### DIFF
--- a/servant-ruby.cabal
+++ b/servant-ruby.cabal
@@ -1,5 +1,5 @@
 name:                servant-ruby
-version:             0.7.0.0
+version:             0.8.0.0
 synopsis:            Generate a Ruby client from a Servant API with Net::HTTP.
 description:         Generate a Ruby client from a Servant API with Net::HTTP.
 homepage:            https://github.com/joneshf/servant-ruby#readme


### PR DESCRIPTION
Dropping `lens` might have gotten rid of a transitive orphan instance.
Instead of risking it for downstream people,
we bump major versions.