### PR TITLE
Remove erroneous `default-language`

### DIFF
--- a/servant-ruby.cabal
+++ b/servant-ruby.cabal
@@ -25,7 +25,6 @@ library
   ghc-options:         -Wall
 
 test-suite doc-test
-  default-language:    Haskell2010
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   hs-source-dirs:      test


### PR DESCRIPTION
This was in here twice and causing the dist to break.
Would be nice to check this as part of CI.