### PR TITLE
Fix list segments

### DIFF
--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -227,13 +227,12 @@ public indent req =
   functionName = req ^. reqFuncName.snakeCaseL.to snake
 
   cleanCaptures  :: [Text]
-  cleanCaptures = cleanCapture . snake <$> captures
+  cleanCaptures = (<>) "  " . cleanCapture . snake <$> captures
 
   cleanCapture  :: Text -> Text
   cleanCapture c =
     T.concat
-      [ "  "
-      , c
+      [ c
       , " = if "
       , c
       , ".kind_of?(Array) then "

--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -148,6 +148,7 @@ class Foo
 <BLANKLINE>
   def post_foo_by_foo_id(foo_id, bar_id, body:, max_forwards:)
     foo_id = if foo_id.kind_of?(Array) then foo_id.join(',') else foo_id end
+<BLANKLINE>
     uri = URI("#{@origin}/foo/#{foo_id}?barId=#{bar_id}")
 <BLANKLINE>
     req = Net::HTTP::Post.new(uri)
@@ -210,7 +211,7 @@ public indent req =
     [ Nothing
     , Just $ "def " <> functionName <> "(" <> argsStr <> ")"
     ]
-    ++ (Just <$> cleanCaptures)
+    ++ cleanCaptures
     ++
     [ Just $ "  uri = URI(" <> url <> ")"
     , Nothing
@@ -226,8 +227,13 @@ public indent req =
   functionName :: Text
   functionName = req ^. reqFuncName.snakeCaseL.to snake
 
-  cleanCaptures  :: [Text]
-  cleanCaptures = (<>) "  " . cleanCapture . snake <$> captures
+  cleanCaptures  :: [Maybe Text]
+  cleanCaptures =
+    case captures of
+      [] -> []
+      xs ->
+        (Just . (<>) "  " . cleanCapture . snake <$> xs)
+        ++ [ Nothing ]
 
   cleanCapture  :: Text -> Text
   cleanCapture c =

--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -147,6 +147,7 @@ class Foo
   end
 <BLANKLINE>
   def post_foo_by_foo_id(foo_id, bar_id, body:, max_forwards:)
+    foo_id = if foo_id.kind_of?(Array) then foo_id.join(',') else foo_id end
     uri = URI("#{@origin}/foo/#{foo_id}?barId=#{bar_id}")
 <BLANKLINE>
     req = Net::HTTP::Post.new(uri)

--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -230,7 +230,18 @@ public indent req =
   cleanCaptures = cleanCapture . snake <$> captures
 
   cleanCapture  :: Text -> Text
-  cleanCapture c = "  " <> c <> " = if " <> c <> ".kind_of?(Array) then " <> c <> ".join(',') else " <> c <> " end"
+  cleanCapture c =
+    T.concat
+      [ "  "
+      , c
+      , " = if "
+      , c
+      , ".kind_of?(Array) then "
+      , c
+      , ".join(',') else "
+      , c
+      , " end"
+      ]
 
   argsStr  :: Text
   argsStr = T.intercalate ", " $ snake <$> args

--- a/src/Servant/Ruby.hs
+++ b/src/Servant/Ruby.hs
@@ -209,7 +209,10 @@ public indent req =
   properIndent indent $
     [ Nothing
     , Just $ "def " <> functionName <> "(" <> argsStr <> ")"
-    , Just $ "  uri = URI(" <> url <> ")"
+    ]
+    ++ (Just <$> cleanCaptures)
+    ++
+    [ Just $ "  uri = URI(" <> url <> ")"
     , Nothing
     , Just $ "  req = Net::HTTP::" <> method <> ".new(uri)"
     ]
@@ -222,6 +225,12 @@ public indent req =
   where
   functionName :: Text
   functionName = req ^. reqFuncName.snakeCaseL.to snake
+
+  cleanCaptures  :: [Text]
+  cleanCaptures = cleanCapture . snake <$> captures
+
+  cleanCapture  :: Text -> Text
+  cleanCapture c = "  " <> c <> " = if " <> c <> ".kind_of?(Array) then " <> c <> ".join(',') else " <> c <> " end"
 
   argsStr  :: Text
   argsStr = T.intercalate ", " $ snake <$> args


### PR DESCRIPTION
`:> API.Capture "ids" [Int]`

Expected:
`uri = URI("origin/foo/1,2,3,4")`

Actual:
`uri = URI("origin/foo/[1,2,3,4]")`

This should join arrays with a `,`.


Let me know what you think about this and if you want me to make any changes.